### PR TITLE
Add Dockerfile for server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM rust:1.76-slim as builder
+WORKDIR /usr/src/riftline
+COPY . .
+RUN apt-get update && apt-get install -y musl-tools pkg-config && rm -rf /var/lib/apt/lists/* \
+    && rustup target add x86_64-unknown-linux-musl \
+    && cargo build --release -p server --target x86_64-unknown-linux-musl
+
+# Runtime stage
+FROM gcr.io/distroless/static
+COPY --from=builder /usr/src/riftline/target/x86_64-unknown-linux-musl/release/server /server
+EXPOSE 50051
+CMD ["/server"]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ just coverage
 Workspace Layout:
 - server/: gRPC server
 - common/: shared code
+
+## Docker
+
+A multi-stage `Dockerfile` is provided for building a minimal runtime image containing the server.
+Build the container with:
+
+```bash
+docker build -t riftline-server .
+```
+
+Run the server:
+
+```bash
+docker run --rm -p 50051:50051 riftline-server
+```
+
+The server will start and listen on port `50051` by default.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds a static server binary
- update README with Docker build instructions

## Testing
- `just build`
- `just test`
- `just coverage`


------
https://chatgpt.com/codex/tasks/task_e_685adbd8e7088328ac1916679744aec5