### PR TITLE
Implement Produce RPC with object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,9 @@ name = "server"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "common",
  "proto",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/proto/protos/riftline.proto
+++ b/proto/protos/riftline.proto
@@ -15,7 +15,7 @@ service OffsetCommit {
 
 message ProduceRequest {
     string topic = 1;
-    bytes message = 2;
+    repeated bytes messages = 2;
 }
 
 message ProduceResponse {

--- a/proto/src/generated/riftline.rs
+++ b/proto/src/generated/riftline.rs
@@ -4,8 +4,8 @@
 pub struct ProduceRequest {
     #[prost(string, tag = "1")]
     pub topic: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
-    pub message: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub messages: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,3 +9,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.10", features = ["transport"] }
 clap = { version = "4", features = ["derive", "env"] }
 tokio-stream = "0.1"
+common = { path = "../common" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,18 +2,22 @@ use proto::riftline::consumer_server::{Consumer, ConsumerServer};
 use proto::riftline::offset_commit_server::{OffsetCommit, OffsetCommitServer};
 use proto::riftline::producer_server::{Producer, ProducerServer};
 use proto::riftline::*;
+use common::object_store::{LocalFileSystemStore, ObjectStore};
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::{Request, Response, Status, transport::Server};
+use tonic::{transport::Server, Request, Response, Status};
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 pub async fn serve(
     addr: SocketAddr,
     shutdown: impl Future<Output = ()> + Send,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let store = Arc::new(LocalFileSystemStore::new("data"));
+
     Server::builder()
-        .add_service(ProducerServer::new(BasicProducer))
+        .add_service(ProducerServer::new(BasicProducer::new(store)))
         .add_service(ConsumerServer::new(BasicConsumer))
         .add_service(OffsetCommitServer::new(BasicOffsetCommit))
         .serve_with_shutdown(addr, shutdown)
@@ -21,15 +25,38 @@ pub async fn serve(
     Ok(())
 }
 
-#[derive(Default)]
-struct BasicProducer;
+#[derive(Clone)]
+struct BasicProducer {
+    store: Arc<dyn ObjectStore + Send + Sync>,
+}
+
+impl BasicProducer {
+    fn new(store: Arc<dyn ObjectStore + Send + Sync>) -> Self {
+        Self { store }
+    }
+}
 
 #[tonic::async_trait]
 impl Producer for BasicProducer {
     async fn produce(
         &self,
-        _request: Request<ProduceRequest>,
+        request: Request<ProduceRequest>,
     ) -> Result<Response<ProduceResponse>, Status> {
+        let req = request.into_inner();
+        let mut bytes = Vec::new();
+        for msg in req.messages {
+            bytes.extend_from_slice(&msg);
+            bytes.push(b'\n');
+        }
+
+        let key = format!("segments/{}/segment_0.log", req.topic);
+
+        self
+            .store
+            .put(&key, &bytes)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
         Ok(Response::new(ProduceResponse {
             partition: 0,
             offset: 0,
@@ -74,6 +101,35 @@ pub fn add(left: u64, right: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use tempfile::tempdir;
+
+    #[derive(Default, Clone)]
+    struct MockStore {
+        data: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    }
+
+    #[tonic::async_trait]
+    impl ObjectStore for MockStore {
+        async fn put(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
+            self.data
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), bytes.to_vec());
+            Ok(())
+        }
+
+        async fn get(&self, key: &str) -> std::io::Result<Vec<u8>> {
+            self
+                .data
+                .lock()
+                .unwrap()
+                .get(key)
+                .cloned()
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "missing"))
+        }
+    }
 
     #[test]
     fn it_works() {
@@ -86,5 +142,48 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let fut = tokio::time::sleep(std::time::Duration::from_millis(10));
         assert!(serve(addr, fut).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn producer_writes_to_store() {
+        let store = Arc::new(MockStore::default());
+        let producer = BasicProducer::new(store.clone());
+
+        let request = Request::new(ProduceRequest {
+            topic: "test".into(),
+            messages: vec![b"one".to_vec(), b"two".to_vec()],
+        });
+
+        producer.produce(request).await.unwrap();
+
+        let data = store
+            .data
+            .lock()
+            .unwrap()
+            .get("segments/test/segment_0.log")
+            .cloned()
+            .unwrap();
+
+        assert_eq!(data, b"one\ntwo\n".to_vec());
+    }
+
+    #[tokio::test]
+    async fn producer_persists_to_files() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(LocalFileSystemStore::new(dir.path()));
+        let producer = BasicProducer::new(store);
+
+        let request = Request::new(ProduceRequest {
+            topic: "topic".into(),
+            messages: vec![b"hello".to_vec()],
+        });
+
+        producer.produce(request).await.unwrap();
+
+        let path = dir
+            .path()
+            .join("segments/topic/segment_0.log");
+        let bytes = tokio::fs::read(path).await.unwrap();
+        assert_eq!(bytes, b"hello\n");
     }
 }


### PR DESCRIPTION
## Summary
- add `messages` field to `ProduceRequest`
- implement `BasicProducer` writing batch to an `ObjectStore`
- persist messages to segment file `segments/<topic>/segment_0.log`
- unit test with mock store and tmp dir to verify persistence

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b22c109b8832887c68630a24f66a7