### PR TITLE
Add consume RPC and integration test

### DIFF
--- a/proto/protos/riftline.proto
+++ b/proto/protos/riftline.proto
@@ -26,6 +26,7 @@ message ProduceResponse {
 message ConsumeRequest {
     string topic = 1;
     int32 partition = 2;
+    int64 offset = 3;
 }
 
 message ConsumeResponse {

--- a/proto/src/generated/riftline.rs
+++ b/proto/src/generated/riftline.rs
@@ -22,6 +22,8 @@ pub struct ConsumeRequest {
     pub topic: ::prost::alloc::string::String,
     #[prost(int32, tag = "2")]
     pub partition: i32,
+    #[prost(int64, tag = "3")]
+    pub offset: i64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,7 @@ proto = { path = "../proto" }
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.10", features = ["transport"] }
 clap = { version = "4", features = ["derive", "env"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 common = { path = "../common" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- implement `Consume` RPC for reading from store
- expose `serve_with_listener` helper for tests
- add integration test to produce and consume messages
- enable tokio-stream `net` feature
- update proto to include offset in `ConsumeRequest`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_e_685b709131f08328924796a718f8b88d