### PR TITLE
Add persistence integration test

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -11,6 +11,11 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+type OffsetKey = (String, i32, String);
+type OffsetMap = HashMap<OffsetKey, i64>;
+/// Shared map of committed offsets indexed by (topic, partition, group).
+type SharedOffsetMap = Arc<Mutex<OffsetMap>>;
+
 pub async fn serve(
     addr: SocketAddr,
     shutdown: impl Future<Output = ()> + Send,
@@ -135,13 +140,13 @@ impl Consumer for BasicConsumer {
 
 #[derive(Clone)]
 struct BasicOffsetCommit {
-    offsets: Arc<Mutex<HashMap<(String, i32, String), i64>>>,
+    offsets: SharedOffsetMap,
 }
 
 impl Default for BasicOffsetCommit {
     fn default() -> Self {
         Self {
-            offsets: Arc::new(Mutex::new(HashMap::new())),
+            offsets: Arc::new(Mutex::new(OffsetMap::new())),
         }
     }
 }

--- a/server/tests/persistence.rs
+++ b/server/tests/persistence.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+use tempfile::tempdir;
+use tokio::net::TcpListener;
+
+use common::object_store::LocalFileSystemStore;
+use proto::riftline::consumer_client::ConsumerClient;
+use proto::riftline::offset_commit_client::OffsetCommitClient;
+use proto::riftline::producer_client::ProducerClient;
+use proto::riftline::*;
+use server::serve_with_listener;
+
+#[tokio::test]
+async fn persistence_roundtrip() {
+    let dir = tempdir().unwrap();
+    let store = Arc::new(LocalFileSystemStore::new(dir.path()));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        let _ = serve_with_listener(listener, store, async {
+            rx.await.ok();
+        })
+        .await;
+    });
+
+    let endpoint = format!("http://{}", addr);
+    let mut producer = ProducerClient::connect(endpoint.clone()).await.unwrap();
+    producer
+        .produce(ProduceRequest {
+            topic: "topic".into(),
+            messages: vec![b"m1".to_vec(), b"m2".to_vec()],
+        })
+        .await
+        .unwrap();
+
+    let mut consumer = ConsumerClient::connect(endpoint.clone()).await.unwrap();
+    let response = consumer
+        .consume(ConsumeRequest {
+            topic: "topic".into(),
+            partition: 0,
+            offset: 0,
+        })
+        .await
+        .unwrap();
+    let mut stream = response.into_inner();
+    let mut messages = Vec::new();
+    while let Some(msg) = stream.message().await.unwrap() {
+        messages.push(msg.message);
+    }
+    assert_eq!(messages, vec![b"m1".to_vec(), b"m2".to_vec()]);
+
+    let mut offset = OffsetCommitClient::connect(endpoint).await.unwrap();
+    offset
+        .commit(CommitRequest {
+            topic: "topic".into(),
+            partition: 0,
+            offset: messages.len() as i64,
+            consumer_group: "group".into(),
+        })
+        .await
+        .unwrap();
+
+    let resp = offset
+        .fetch(FetchRequest {
+            topic: "topic".into(),
+            partition: 0,
+            consumer_group: "group".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.offset, messages.len() as i64);
+
+    tx.send(()).unwrap();
+}


### PR DESCRIPTION
## Summary
- fix clippy type complexity in BasicOffsetCommit
- add local filesystem integration test verifying persistence and offset commit
- document offset map type

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_685c23f2772883289ec7df6a0f292b48